### PR TITLE
Resolve getBoolean overflow

### DIFF
--- a/dough-data/src/main/java/io/github/bakedlibs/dough/data/persistent/PersistentDataAPI.java
+++ b/dough-data/src/main/java/io/github/bakedlibs/dough/data/persistent/PersistentDataAPI.java
@@ -377,7 +377,8 @@ public final class PersistentDataAPI {
      * @return An Optional describing the result
      */
     public static Optional<Boolean> getOptionalBoolean(PersistentDataHolder holder, NamespacedKey key) {
-        return !hasBoolean(holder, key) ? Optional.empty() : Optional.of(getBoolean(holder, key));
+        Byte b = holder.getPersistentDataContainer().get(key, PersistentDataType.BYTE);
+        return b == null ? Optional.empty() : Optional.of(b == 1);
     }
 
     /**


### PR DESCRIPTION
PersistentDataApi#getBoolean calls PersistentDataApi#getOptionalBoolean which calls PersistentDataApi#getBoolean causing an overflow.

Same as PR#201 for CS-CoreLib2 without the final modifier