### PR TITLE
Fix error on startup

### DIFF
--- a/dough-reflection/src/main/java/io/github/bakedlibs/dough/reflection/ReflectionUtils.java
+++ b/dough-reflection/src/main/java/io/github/bakedlibs/dough/reflection/ReflectionUtils.java
@@ -317,7 +317,7 @@ public final class ReflectionUtils {
      */
     public static @Nonnull Class<?> getOBCClass(@Nonnull String name) throws ClassNotFoundException {
         try {
-            return Class.forName("org.bukkit.craftbukkit." + getVersionSpecificPackage(false) + '.' + name);
+            return Class.forName("org.bukkit.craftbukkit." + getVersionSpecificPackage(false) + name);
         } catch (UnknownServerVersionException e) {
             throw new IllegalStateException("No version check should be performed here.", e);
         }


### PR DESCRIPTION
removed the extra '.' added to OBC class packages which fixes some errors on startup.