### PR TITLE
Added 1.18 support

### DIFF
--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter.java
@@ -25,9 +25,12 @@ public interface ItemNameAdapter {
             if (MinecraftVersion.isMocked()) {
                 // Special case for MockBukkit
                 return new ItemNameAdapterMockBukkit();
+            } else if (version.isAtLeast(1, 18)) {
+                // 1.18+ mappings
+                return new ItemNameAdapter18();
             } else if (version.isAtLeast(1, 17)) {
                 // 1.17+ mappings
-                return new ItemNameAdapterAfter17();
+                return new ItemNameAdapter17();
             } else {
                 // Old mappings
                 return new ItemNameAdapterBefore17();

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter17.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter17.java
@@ -1,0 +1,34 @@
+package io.github.bakedlibs.dough.items.nms;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.bukkit.inventory.ItemStack;
+
+import io.github.bakedlibs.dough.reflection.ReflectionUtils;
+import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
+
+class ItemNameAdapter17 implements ItemNameAdapter {
+
+    private final Method getCopy;
+    private final Method getName;
+    private final Method toString;
+
+    ItemNameAdapter17() throws NoSuchMethodException, SecurityException, ClassNotFoundException, UnknownServerVersionException {
+        super();
+
+        getCopy = ReflectionUtils.getOBCClass("inventory.CraftItemStack").getMethod("asNMSCopy", ItemStack.class);
+        getName = ReflectionUtils.getMethod(ReflectionUtils.getNetMinecraftClass("world.item.ItemStack"), "getName");
+        toString = ReflectionUtils.getMethod(ReflectionUtils.getNetMinecraftClass("network.chat.IChatBaseComponent"), "getString");
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public String getName(ItemStack item) throws IllegalAccessException, InvocationTargetException {
+        Object instance = getCopy.invoke(null, item);
+        return (String) toString.invoke(getName.invoke(instance));
+    }
+
+}

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter18.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter18.java
@@ -10,17 +10,17 @@ import org.bukkit.inventory.ItemStack;
 import io.github.bakedlibs.dough.reflection.ReflectionUtils;
 import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
 
-class ItemNameAdapterAfter17 implements ItemNameAdapter {
+class ItemNameAdapter18 implements ItemNameAdapter {
 
     private final Method getCopy;
     private final Method getName;
     private final Method toString;
 
-    ItemNameAdapterAfter17() throws NoSuchMethodException, SecurityException, ClassNotFoundException, UnknownServerVersionException {
+    ItemNameAdapter18() throws NoSuchMethodException, SecurityException, ClassNotFoundException, UnknownServerVersionException {
         super();
 
         getCopy = ReflectionUtils.getOBCClass("inventory.CraftItemStack").getMethod("asNMSCopy", ItemStack.class);
-        getName = ReflectionUtils.getMethod(ReflectionUtils.getNetMinecraftClass("world.item.ItemStack"), "getName");
+        getName = ReflectionUtils.getMethod(ReflectionUtils.getNetMinecraftClass("world.item.ItemStack"), "getDisplayName");
         toString = ReflectionUtils.getMethod(ReflectionUtils.getNetMinecraftClass("network.chat.IChatBaseComponent"), "getString");
     }
 

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
@@ -6,6 +6,7 @@ import java.util.logging.Level;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.bakedlibs.dough.versions.Version;
 import org.bukkit.block.Block;
 
 import com.mojang.authlib.GameProfile;
@@ -26,9 +27,12 @@ public interface PlayerHeadAdapter {
         try {
             MinecraftVersion version = MinecraftVersion.get();
 
-            if (version.isAtLeast(1, 17)) {
-                // 1.17+ mappings
+            if (version.getMajorVersion() == 1 && version.getMinorVersion() == 17) {
+                // 1.17 mappings
                 return new PlayerHeadAdapter17();
+            } else if (version.isAtLeast(1, 18)) {
+                // 1.18 mappings
+                return new PlayerHeadAdapter18();
             } else {
                 // Old mappings
                 return new PlayerHeadAdapterBefore17();

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
@@ -28,10 +28,10 @@ public interface PlayerHeadAdapter {
 
             if (version.isAtLeast(1, 18)) {
                 // 1.18 mappings
-                return new PlayerHeadAdapter17();
+                return new PlayerHeadAdapter18();
             } else if (version.isAtLeast(1, 17)) {
                 // 1.17 mappings
-                return new PlayerHeadAdapter18();
+                return new PlayerHeadAdapter17();
             } else {
                 // Old mappings
                 return new PlayerHeadAdapterBefore17();

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
@@ -28,7 +28,7 @@ public interface PlayerHeadAdapter {
 
             if (version.isAtLeast(1, 17)) {
                 // 1.17+ mappings
-                return new PlayerHeadAdapterAfter17();
+                return new PlayerHeadAdapter17();
             } else {
                 // Old mappings
                 return new PlayerHeadAdapterBefore17();

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
@@ -26,11 +26,11 @@ public interface PlayerHeadAdapter {
         try {
             MinecraftVersion version = MinecraftVersion.get();
 
-            if (version.getMajorVersion() == 1 && version.getMinorVersion() == 17) {
-                // 1.17 mappings
-                return new PlayerHeadAdapter17();
-            } else if (version.isAtLeast(1, 18)) {
+            if (version.isAtLeast(1, 18)) {
                 // 1.18 mappings
+                return new PlayerHeadAdapter17();
+            } else if (version.isAtLeast(1, 17)) {
+                // 1.17 mappings
                 return new PlayerHeadAdapter18();
             } else {
                 // Old mappings

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
@@ -6,7 +6,6 @@ import java.util.logging.Level;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.bakedlibs.dough.versions.Version;
 import org.bukkit.block.Block;
 
 import com.mojang.authlib.GameProfile;

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter17.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter17.java
@@ -1,0 +1,49 @@
+package io.github.bakedlibs.dough.skins.nms;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.bukkit.block.Block;
+
+import com.mojang.authlib.GameProfile;
+
+import io.github.bakedlibs.dough.reflection.ReflectionUtils;
+import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
+
+class PlayerHeadAdapter17 implements PlayerHeadAdapter {
+
+    private final Constructor<?> newPosition;
+
+    private final Method getHandle;
+    private final Method getTileEntity;
+    private final Method setGameProfile;
+
+    PlayerHeadAdapter17() throws NoSuchMethodException, SecurityException, ClassNotFoundException, UnknownServerVersionException {
+        setGameProfile = ReflectionUtils.getNetMinecraftClass("world.level.block.entity.TileEntitySkull").getMethod("setGameProfile", GameProfile.class);
+        getHandle = ReflectionUtils.getOBCClass("CraftWorld").getMethod("getHandle");
+
+        Class<?> blockPosition = ReflectionUtils.getNetMinecraftClass("core.BlockPosition");
+        newPosition = ReflectionUtils.getConstructor(blockPosition, int.class, int.class, int.class);
+        getTileEntity = ReflectionUtils.getNMSClass("level.WorldServer").getMethod("getTileEntity", blockPosition);
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public @Nullable Object getTileEntity(Block block) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        Object world = getHandle.invoke(block.getWorld());
+
+        Object position = newPosition.newInstance(block.getX(), block.getY(), block.getZ());
+        return getTileEntity.invoke(world, position);
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public void setGameProfile(Object tileEntity, GameProfile profile) throws IllegalAccessException, InvocationTargetException {
+        setGameProfile.invoke(tileEntity, profile);
+    }
+
+}

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter18.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter18.java
@@ -1,20 +1,17 @@
 package io.github.bakedlibs.dough.skins.nms;
 
+import com.mojang.authlib.GameProfile;
+import io.github.bakedlibs.dough.reflection.ReflectionUtils;
+import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
+import org.bukkit.block.Block;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-
-import org.bukkit.block.Block;
-
-import com.mojang.authlib.GameProfile;
-
-import io.github.bakedlibs.dough.reflection.ReflectionUtils;
-import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
-
-class PlayerHeadAdapterAfter17 implements PlayerHeadAdapter {
+class PlayerHeadAdapter18 implements PlayerHeadAdapter {
 
     private final Constructor<?> newPosition;
 
@@ -22,13 +19,12 @@ class PlayerHeadAdapterAfter17 implements PlayerHeadAdapter {
     private final Method getTileEntity;
     private final Method setGameProfile;
 
-    PlayerHeadAdapterAfter17() throws NoSuchMethodException, SecurityException, ClassNotFoundException, UnknownServerVersionException {
-        setGameProfile = ReflectionUtils.getNetMinecraftClass("world.level.block.entity.TileEntitySkull").getMethod("setGameProfile", GameProfile.class);
+    PlayerHeadAdapter18() throws NoSuchMethodException, SecurityException, ClassNotFoundException, UnknownServerVersionException {
+        setGameProfile = ReflectionUtils.getNetMinecraftClass("world.level.block.entity.TileEntitySkull").getMethod("a", GameProfile.class);
         getHandle = ReflectionUtils.getOBCClass("CraftWorld").getMethod("getHandle");
-
         Class<?> blockPosition = ReflectionUtils.getNetMinecraftClass("core.BlockPosition");
         newPosition = ReflectionUtils.getConstructor(blockPosition, int.class, int.class, int.class);
-        getTileEntity = ReflectionUtils.getNMSClass("level.WorldServer").getMethod("getTileEntity", blockPosition);
+        getTileEntity = ReflectionUtils.getNMSClass("level.WorldServer").getMethod("getBlockEntity", blockPosition, boolean.class);
     }
 
     @Override
@@ -37,7 +33,7 @@ class PlayerHeadAdapterAfter17 implements PlayerHeadAdapter {
         Object world = getHandle.invoke(block.getWorld());
 
         Object position = newPosition.newInstance(block.getX(), block.getY(), block.getZ());
-        return getTileEntity.invoke(world, position);
+        return getTileEntity.invoke(world, position, true);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -296,8 +296,8 @@
 
         <dependency>
             <groupId>com.github.seeseemelk</groupId>
-            <artifactId>MockBukkit-v1.16</artifactId>
-            <version>1.5.2</version>
+            <artifactId>MockBukkit-v1.18</artifactId>
+            <version>1.14.0</version>
             <scope>test</scope>
 
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18-R0.1-SNAPSHOT</version>
+            <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.17-R0.1-SNAPSHOT</version>
+            <version>1.18-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Update poms to use spigot 1.18
Update the dough-skins:
- add a new PlayerHeadAdapter18 for 1.18 mappings
