### PR TITLE
Closes #106

### DIFF
--- a/dough-api/pom.xml
+++ b/dough-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-api</artifactId>

--- a/dough-chat/pom.xml
+++ b/dough-chat/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-chat</artifactId>

--- a/dough-common/pom.xml
+++ b/dough-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-common</artifactId>

--- a/dough-config/pom.xml
+++ b/dough-config/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-config</artifactId>

--- a/dough-data/pom.xml
+++ b/dough-data/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-data</artifactId>

--- a/dough-inventories/pom.xml
+++ b/dough-inventories/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-inventories</artifactId>

--- a/dough-items/pom.xml
+++ b/dough-items/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-items</artifactId>

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter18.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter18.java
@@ -20,7 +20,8 @@ class ItemNameAdapter18 implements ItemNameAdapter {
         super();
 
         getCopy = ReflectionUtils.getOBCClass("inventory.CraftItemStack").getMethod("asNMSCopy", ItemStack.class);
-        getName = ReflectionUtils.getMethod(ReflectionUtils.getNetMinecraftClass("world.item.ItemStack"), "getDisplayName");
+        // Spigot has re-obf'd names however you can get mapped jar... so we do this
+        getName = ReflectionUtils.getMethodOrAlternative(ReflectionUtils.getNetMinecraftClass("world.item.ItemStack"), "getDisplayName", "G");
         toString = ReflectionUtils.getMethod(ReflectionUtils.getNetMinecraftClass("network.chat.IChatBaseComponent"), "getString");
     }
 

--- a/dough-protection/pom.xml
+++ b/dough-protection/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-protection</artifactId>

--- a/dough-recipes/pom.xml
+++ b/dough-recipes/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-recipes</artifactId>

--- a/dough-reflection/pom.xml
+++ b/dough-reflection/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-reflection</artifactId>

--- a/dough-reflection/src/main/java/io/github/bakedlibs/dough/reflection/ReflectionUtils.java
+++ b/dough-reflection/src/main/java/io/github/bakedlibs/dough/reflection/ReflectionUtils.java
@@ -79,6 +79,22 @@ public final class ReflectionUtils {
     }
 
     /**
+     * Returns a certain Method in the specified Class
+     *
+     * @param c
+     *            The Class in which the Method is in
+     * @param method
+     *            The Method you are looking for
+     * @param alternative
+     *            The alternative Method you are looking for
+     * @return The found Method
+     */
+    public static @Nullable Method getMethodOrAlternative(@Nonnull Class<?> c, @Nonnull String method, @Nonnull String alternative) {
+        Method mainMethod = getMethod(c, method);
+        return mainMethod != null ? mainMethod : getMethod(c, alternative);
+    }
+
+    /**
      * Returns the Method with certain Parameters
      *
      * @param c

--- a/dough-scheduling/pom.xml
+++ b/dough-scheduling/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-scheduling</artifactId>

--- a/dough-skins/pom.xml
+++ b/dough-skins/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-skins</artifactId>

--- a/dough-updater/pom.xml
+++ b/dough-updater/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baked-libs</groupId>
         <artifactId>dough</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>dough-updater</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.baked-libs</groupId>
     <artifactId>dough</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Fixes the 1.18 compatibility for ItemNameAdapter. Tested with debug code and pedestal. Spigot doesn't make life hard :^)