### PR TITLE
Update LogBlock dependency/compatibility

### DIFF
--- a/dough-api/pom.xml
+++ b/dough-api/pom.xml
@@ -175,6 +175,10 @@
             <id>funnyguilds-repo</id>
             <url>https://repo.panda-lang.org/releases</url>
         </repository>
+        <repository>
+            <id>logblock-repo</id>
+            <url>https://www.iani.de/nexus/content/repositories/snapshots/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -285,9 +289,9 @@
 
         <!-- LogBlock -->
         <dependency>
-            <groupId>com.github.LogBlock</groupId>
-            <artifactId>LogBlock</artifactId>
-            <version>d98d46d0c9</version>
+            <groupId>de.diddiz</groupId>
+            <artifactId>logblock</artifactId>
+            <version>1.17.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/dough-protection/pom.xml
+++ b/dough-protection/pom.xml
@@ -50,6 +50,10 @@
             <id>funnyguilds-repo</id>
             <url>https://repo.panda-lang.org/releases</url>
         </repository>
+        <repository>
+            <id>logblock-repo</id>
+            <url>https://www.iani.de/nexus/content/repositories/snapshots/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -98,9 +102,9 @@
 
         <!-- LogBlock -->
         <dependency>
-            <groupId>com.github.LogBlock</groupId>
-            <artifactId>LogBlock</artifactId>
-            <version>d98d46d0c9</version>
+            <groupId>de.diddiz</groupId>
+            <artifactId>logblock</artifactId>
+            <version>1.17.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/loggers/LogBlockLogger.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/loggers/LogBlockLogger.java
@@ -9,7 +9,7 @@ import io.github.bakedlibs.dough.protection.ProtectionLogger;
 import de.diddiz.LogBlock.Actor;
 import de.diddiz.LogBlock.Consumer;
 import de.diddiz.LogBlock.LogBlock;
-import de.diddiz.util.LoggingUtil;
+import de.diddiz.LogBlock.util.LoggingUtil;
 
 public class LogBlockLogger implements ProtectionLogger {
 


### PR DESCRIPTION
Since https://github.com/LogBlock/LogBlock/commit/e430ee073f074ab7c7fb827253d54a9c3a492128 LoggingUtil was move to different package this commit fixes the issue