### PR TITLE
re-enable checking for worldguard bypass

### DIFF
--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/WorldGuardProtectionModule.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/WorldGuardProtectionModule.java
@@ -53,11 +53,9 @@ public class WorldGuardProtectionModule implements ProtectionModule {
         com.sk89q.worldedit.world.World world = BukkitAdapter.adapt(l.getWorld());
         LocalPlayer player = worldguard.wrapOfflinePlayer(p);
 
-        /*
-         * if (platform.getSessionManager().hasBypass(player, world)) {
-         * return true;
-         * }
-         */
+        if (platform.getSessionManager().hasBypass(player, world)) {
+            return true;
+        }
 
         if (action.getType() != ActionType.BLOCK) {
             Set<ProtectedRegion> regions = container.get(world).getApplicableRegions(BlockVector3.at(l.getX(), l.getY(), l.getZ())).getRegions();


### PR DESCRIPTION
This makes the return value for hasPermission more consistent with actual permission; namely, it returns ``true`` if the player has permission to bypass 

Edit by Walshy:
This was originally commented out in Sept 2019 - https://github.com/baked-libs/dough/commit/c8586bd42fa9a681b9f3c2c1902e16331f81fc7a