### PR TITLE
Fix repos in dough-protection

### DIFF
--- a/dough-protection/pom.xml
+++ b/dough-protection/pom.xml
@@ -40,11 +40,7 @@
         </repository>
         <repository>
             <id>worldedit-worldguard-repo</id>
-            <url>https://maven.sk89q.com/repo/</url>
-        </repository>
-        <repository>
-            <id>IntellectualSites</id>
-            <url>https://mvn.intellectualsites.com/content/repositories/snapshots/</url>
+            <url>https://maven.enginehub.org/repo/</url>
         </repository>
         <repository>
             <id>funnyguilds-repo</id>


### PR DESCRIPTION
- Remove mvn.intellectualsites.com (releases are on maven central and snapshots on oss snapshots)
- Change the maven.sk89q.com to maven.enginehub.org