### PR TITLE
fix BlockPosition#getY

### DIFF
--- a/dough-data/src/main/java/io/github/bakedlibs/dough/blocks/BlockPosition.java
+++ b/dough-data/src/main/java/io/github/bakedlibs/dough/blocks/BlockPosition.java
@@ -124,7 +124,7 @@ public final class BlockPosition {
      * @return This blocks y coordinate.
      */
     public int getY() {
-        return (int) (this.position & 0xFFF);
+        return (int) (this.position << 52 >> 52);
     }
 
     /**

--- a/dough-data/src/test/java/io/github/bakedlibs/dough/blocks/TestBlockPosition.java
+++ b/dough-data/src/test/java/io/github/bakedlibs/dough/blocks/TestBlockPosition.java
@@ -1,0 +1,33 @@
+package io.github.bakedlibs.dough.blocks;
+
+import be.seeseemelk.mockbukkit.WorldMock;
+import org.bukkit.World;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestBlockPosition {
+
+    @Test
+    void testBlockPositions() {
+        World world = new WorldMock();
+        int x = 57123, y = 286, z = 862;
+        BlockPosition bp = new BlockPosition(world, x, y, z);
+
+        Assertions.assertEquals(world, bp.getWorld());
+        Assertions.assertEquals(x, bp.getX());
+        Assertions.assertEquals(y, bp.getY());
+        Assertions.assertEquals(z, bp.getZ());
+    }
+
+    @Test
+    void testNegativeBlockPositions() {
+        World world = new WorldMock();
+        int x = -57123, y = -38, z = -862;
+        BlockPosition bp = new BlockPosition(world, x, y, z);
+
+        Assertions.assertEquals(x, bp.getX());
+        Assertions.assertEquals(y, bp.getY());
+        Assertions.assertEquals(z, bp.getZ());
+    }
+
+}


### PR DESCRIPTION
#162 

using `& 0xFFF` cuts off leading 1s which happens when y is negative

also added unit tests