### PR TITLE
Bump HuskTowns to v1.8 (package change)

### DIFF
--- a/dough-protection/pom.xml
+++ b/dough-protection/pom.xml
@@ -228,9 +228,9 @@
 
         <!-- HuskTowns -->
         <dependency>
-            <groupId>com.github.WiIIiam278</groupId>
+            <groupId>net.william278</groupId>
             <artifactId>HuskTowns</artifactId>
-            <version>1.7</version>
+            <version>1.8</version>
             <scope>provided</scope>
         </dependency>
 

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/HuskTownsProtectionModule.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/HuskTownsProtectionModule.java
@@ -2,8 +2,8 @@ package io.github.bakedlibs.dough.protection.modules;
 
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.bakedlibs.dough.protection.ProtectionModule;
-import me.william278.husktowns.HuskTownsAPI;
-import me.william278.husktowns.listener.ActionType;
+import net.william278.husktowns.HuskTownsAPI;
+import net.william278.husktowns.listener.ActionType;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.plugin.Plugin;


### PR DESCRIPTION
Hi all,

This pull request bumps HuskTowns to v1.8. I'm submitting a manual PR rather than letting Dependabot do the dirty lifting since there's a package change in this release (`me.william278` --> `net.william278`) -- #186 won't work!

This PR simply updates the module to use the `net.william278` package and bumps the dependency to v1.8.

Thanks :-)