### PR TITLE
Update HuskTowns dependency and changed module to remove deprecated methods

### DIFF
--- a/dough-protection/pom.xml
+++ b/dough-protection/pom.xml
@@ -230,7 +230,7 @@
         <dependency>
             <groupId>net.william278</groupId>
             <artifactId>HuskTowns</artifactId>
-            <version>1.8</version>
+            <version>2.5.3</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
* This denies perms for any offline players since the HuskTowns API requires OnlineUsers, which is their own wrapper for players.