### PR TITLE
Fix null pointer exception for game profiles

### DIFF
--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.bukkit.Bukkit;
 import org.bukkit.inventory.meta.SkullMeta;
 
 import com.mojang.authlib.GameProfile;
@@ -37,7 +38,7 @@ final class CustomGameProfile extends GameProfile {
         ReflectionUtils.setFieldValue(meta, "profile", this);
 
         // Forces SkullMeta to properly deserialize and serialize the profile
-        meta.setOwningPlayer(meta.getOwningPlayer());
+        meta.setOwnerProfile(Bukkit.createPlayerProfile(meta.getOwningPlayer().getUniqueId(), PLAYER_NAME));
 
         // Now override the texture again
         ReflectionUtils.setFieldValue(meta, "profile", this);


### PR DESCRIPTION
This change stops the ``NullPointerException`` from occurring when having a non existing uuid in a ``CustomGameProfile``

Credit: StarWishsama