### PR TITLE
Make PlayerSkin#getProfile public

### DIFF
--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/PlayerSkin.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/PlayerSkin.java
@@ -35,7 +35,7 @@ public final class PlayerSkin {
         this.profile = new CustomGameProfile(uuid, base64skinTexture, url);
     }
 
-    final @Nonnull CustomGameProfile getProfile() {
+    public final @Nonnull CustomGameProfile getProfile() {
         return profile;
     }
     


### PR DESCRIPTION
Needed for another fix, reflection sounds like a worse idea than making a getter public (sorry Justin)

Pls approve