### PR TITLE
Make CustomGameProfile public and add a getBase64Texture to fix Slimefun4#4071

### DIFF
--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
@@ -18,7 +18,7 @@ import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
 import org.bukkit.profile.PlayerProfile;
 import org.bukkit.profile.PlayerTextures;
 
-final class CustomGameProfile extends GameProfile {
+public final class CustomGameProfile extends GameProfile {
 
     /**
      * The player name for this profile.
@@ -61,4 +61,13 @@ final class CustomGameProfile extends GameProfile {
         ReflectionUtils.setFieldValue(meta, "profile", this);
     }
 
+    /**
+     * Get the base64 encoded texture from the underline GameProfile.
+     *
+     * @return the base64 encoded texture.
+     */
+    @Nullable
+    public String getBase64Texture() {
+        return getProperties().get(PROPERTY_KEY).iterator().next().getValue();
+    }
 }


### PR DESCRIPTION
Allows fixing https://github.com/Slimefun/Slimefun4/issues/4071

In `GitHubTask` we're doing `Optional<String> skin = Optional.of(future.get().toString());` where `future.get()` returns `PlayerSkin`. However, `PlayerSkin` does not have a `toString()` function and therefore this was resulting in the normal Object#toString meaning `skin` was like `io.github.thebusybiscuit.slimefun4.libraries.dough.skins.PlayerSkin@abcdef123` instead of the base64 texture.

This update allows us to get the CustomGameProfile from the PlayerSkin	(function made available here: https://github.com/baked-libs/dough/commit/08722d5b889632fbc5d22f31508a2fec424dc112) and we can now do `getBase64Texture` to grab the needed texture.

Slimefun PR pending dough merge: https://github.com/Slimefun/Slimefun4/pull/4072