### PR TITLE
Updated a bunch to support mockbukkit 1.20.4 for Slimefun

### DIFF
--- a/dough-api/pom.xml
+++ b/dough-api/pom.xml
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>com.mojang</groupId>
             <artifactId>authlib</artifactId>
-            <version>1.5.25</version>
+            <version>6.0.52</version>
             <scope>provided</scope>
         </dependency>
 

--- a/dough-skins/pom.xml
+++ b/dough-skins/pom.xml
@@ -38,8 +38,14 @@
         <dependency>
             <groupId>com.mojang</groupId>
             <artifactId>authlib</artifactId>
-            <version>1.5.25</version>
+            <version>6.0.52</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/dough-skins/pom.xml
+++ b/dough-skins/pom.xml
@@ -41,12 +41,6 @@
             <version>6.0.52</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.10.1</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
@@ -62,7 +62,6 @@ public final class CustomGameProfile extends GameProfile {
 
             // Now override the texture again
             ReflectionUtils.setFieldValue(meta, "profile", this);
-
         }
 
     }

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.mojang.authlib.properties.PropertyMap;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.meta.SkullMeta;
 
@@ -45,22 +46,25 @@ public final class CustomGameProfile extends GameProfile {
     }
 
     void apply(@Nonnull SkullMeta meta) throws NoSuchFieldException, IllegalAccessException, UnknownServerVersionException {
-        ReflectionUtils.setFieldValue(meta, "profile", this);
 
         // Forces SkullMeta to properly deserialize and serialize the profile
         // setOwnerProfile was added in 1.18, but setOwningPlayer throws a NullPointerException since 1.20.2
         if (MinecraftVersion.get().isAtLeast(MinecraftVersion.parse("1.20"))) {
-            PlayerProfile playerProfile = Bukkit.createPlayerProfile(meta.getOwningPlayer().getUniqueId(), PLAYER_NAME);
+            PlayerProfile playerProfile = Bukkit.createPlayerProfile(UUID.randomUUID(), PLAYER_NAME);
             PlayerTextures playerTextures = playerProfile.getTextures();
             playerTextures.setSkin(this.skinUrl);
             playerProfile.setTextures(playerTextures);
             meta.setOwnerProfile(playerProfile);
         } else {
+            ReflectionUtils.setFieldValue(meta, "profile", this);
+
             meta.setOwningPlayer(meta.getOwningPlayer());
+
+            // Now override the texture again
+            ReflectionUtils.setFieldValue(meta, "profile", this);
+
         }
 
-        // Now override the texture again
-        ReflectionUtils.setFieldValue(meta, "profile", this);
     }
 
     /**

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/PlayerSkin.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/PlayerSkin.java
@@ -25,7 +25,7 @@ import com.google.gson.JsonParser;
 
 import io.github.bakedlibs.dough.common.DoughLogger;
 
-public final class PlayerSkin {
+public class PlayerSkin {
 
     private static final String ERROR_TOKEN = "error";
 


### PR DESCRIPTION
Made changes to support MockBukkit 1.20.4

* Updated authlib - we were on a very old version
* Moved reflections into the else statement since this is not needed for 1.20+ - this caused problems on 1.20.4 as the `profile` field no longer exists
* Unfinallised PlayerSkin