### PR TITLE
Change the way we handle text passthrough in ChatInput

### DIFF
--- a/dough-chat/src/main/java/io/github/bakedlibs/dough/chat/ChatInputListener.java
+++ b/dough-chat/src/main/java/io/github/bakedlibs/dough/chat/ChatInputListener.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.EventHandler;
@@ -56,8 +55,7 @@ class ChatInputListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onChat(AsyncPlayerChatEvent e) {
-        String msg = e.getMessage().replace(ChatColor.COLOR_CHAR, '&');
-        checkInput(e, e.getPlayer(), msg);
+        checkInput(e, e.getPlayer(), e.getMessage());
     }
 
     @EventHandler


### PR DESCRIPTION
Don't convert from MC special color code -> & in ChatInput, pass through the raw message

This is what plugins are used to handling, we really only ever turn user friendly (&) -> special rather than the other way around and don't ever strip user friendly