### PR TITLE
Get ready for Paper no longer relocating CB under MC ver

### DIFF
--- a/dough-common/pom.xml
+++ b/dough-common/pom.xml
@@ -13,4 +13,19 @@
     <artifactId>dough-common</artifactId>
     <packaging>jar</packaging>
 
+    <repositories>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>    
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc</groupId>
+            <artifactId>paperlib</artifactId>
+            <version>1.0.7</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/dough-reflection/src/main/java/io/github/bakedlibs/dough/reflection/ReflectionUtils.java
+++ b/dough-reflection/src/main/java/io/github/bakedlibs/dough/reflection/ReflectionUtils.java
@@ -14,6 +14,7 @@ import org.bukkit.Bukkit;
 
 import io.github.bakedlibs.dough.versions.MinecraftVersion;
 import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
+import io.papermc.lib.PaperLib;
 
 /**
  * This class provides some useful static methods to perform reflection.
@@ -53,10 +54,18 @@ public final class ReflectionUtils {
 
         if (versionSpecificPackage == null) {
             String packageName = Bukkit.getServer().getClass().getPackage().getName();
-            versionSpecificPackage = packageName.substring(packageName.lastIndexOf('.') + 1);
+            
+            // Paper are no longer relocating CB to live under the version in the package name
+            // This means org.bukkit.craftbukkit.v1_20_R1.CraftWorld is now org.bukkit.craftbukkit.CraftWorld
+            // So we check that it is Paper and does NOT have the _v1 in the package name and just return an empty string
+            if (PaperLib.isPaper() && !packageName.contains(".v1_")) {
+                return (versionSpecificPackage = "");
+            }
+
+            versionSpecificPackage = packageName.substring(packageName.lastIndexOf('.') + 1) + '.';
         }
 
-        return versionSpecificPackage + '.';
+        return versionSpecificPackage;
     }
 
     /**


### PR DESCRIPTION
Paper are no longer putting CB under a package like v1_20_R1 so let's update our code to handle tbat

https://github.com/PaperMC/testing/releases/tag/no-relocation
https://forums.papermc.io/threads/paper-velocity-1-20-4.998/#post-2955