### PR TITLE
Fix #249 causing failures trying to import dough as a dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 **pom.xml.versionsBackup
 dependency-reduced-pom.xml
 publish.bat
+.ci-friendly-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,20 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.outbrain.swinfra</groupId>
+                <artifactId>ci-friendly-flatten-maven-plugin</artifactId>
+                <version>1.0.17</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>clean</goal>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
I swear I had this working previously, either way, we need to flatten the pom per https://maven.apache.org/maven-ci-friendly.html#install-deploy

We aren't using the Maven official one as that one seems to have some issues, company behind this hit the same issues and made a lightweight alternative.

Now we can properly just change `revision` and `mvn install`