### PR TITLE
fix(items): add check for PDC

### DIFF
--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/ItemUtils.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/ItemUtils.java
@@ -115,6 +115,11 @@ public final class ItemUtils {
                 return false;
             }
 
+            // PersistentDataContainer
+            if (!aMeta.getPersistentDataContainer().equals(bMeta.getPersistentDataContainer())) {
+                return false;
+            }
+
             // Display Name
             if (aMeta.hasDisplayName() != bMeta.hasDisplayName()) {
                 return false;


### PR DESCRIPTION
`ItemUtils#canStack` lacks a comparison of PDCs, resulting in items with the same everything else but different PDCs being able to stack, which is a kind of illegal item duplication.

The PDC check is added before display name and lore.