### PR TITLE
Stop Extending Mojang's Game Profile on CustomGameProfile

### DIFF
--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
@@ -18,7 +18,7 @@ import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
 import org.bukkit.profile.PlayerProfile;
 import org.bukkit.profile.PlayerTextures;
 
-public final class CustomGameProfile extends GameProfile {
+public final class CustomGameProfile {
 
     /**
      * The player name for this profile.

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/CustomGameProfile.java
@@ -33,9 +33,10 @@ public final class CustomGameProfile extends GameProfile {
 
     private final URL skinUrl;
     private final String texture;
-
-    CustomGameProfile(@Nonnull UUID uuid, @Nullable String texture, @Nonnull URL url) {
-        super(uuid, PLAYER_NAME);
+    private final GameProfile delegate;
+    
+    public CustomGameProfile(@Nonnull UUID uuid, @Nullable String texture, @Nonnull URL url) {
+        this.delegate = new GameProfile(uuid, PLAYER_NAME);
         this.skinUrl = url;
         this.texture = texture;
 
@@ -44,24 +45,22 @@ public final class CustomGameProfile extends GameProfile {
         }
     }
 
-    void apply(@Nonnull SkullMeta meta) throws NoSuchFieldException, IllegalAccessException, UnknownServerVersionException {
-        // setOwnerProfile was added in 1.18, but getOwningPlayer throws a NullPointerException since 1.20.2
+    public void apply(@Nonnull SkullMeta meta) throws NoSuchFieldException, IllegalAccessException, UnknownServerVersionException {
         if (MinecraftVersion.get().isAtLeast(MinecraftVersion.parse("1.20"))) {
-            PlayerProfile playerProfile = Bukkit.createPlayerProfile(this.getId(), PLAYER_NAME);
+            PlayerProfile playerProfile = Bukkit.createPlayerProfile(this.delegate.getId(), PLAYER_NAME);
             PlayerTextures playerTextures = playerProfile.getTextures();
             playerTextures.setSkin(this.skinUrl);
             playerProfile.setTextures(playerTextures);
             meta.setOwnerProfile(playerProfile);
         } else {
-            // Forces SkullMeta to properly deserialize and serialize the profile
-            ReflectionUtils.setFieldValue(meta, "profile", this);
+            // Force SkullMeta to use our wrapped GameProfile
+            ReflectionUtils.setFieldValue(meta, "profile", this.delegate);
 
             meta.setOwningPlayer(meta.getOwningPlayer());
 
-            // Now override the texture again
-            ReflectionUtils.setFieldValue(meta, "profile", this);
+            // Override the texture again
+            ReflectionUtils.setFieldValue(meta, "profile", this.delegate);
         }
-
     }
 
     /**
@@ -72,5 +71,9 @@ public final class CustomGameProfile extends GameProfile {
     @Nullable
     public String getBase64Texture() {
         return this.texture;
+    }
+    
+    public GameProfile getHandle() {
+        return this.delegate;
     }
 }


### PR DESCRIPTION
Mojang has made breaking changes to `GameProfile`, Causing Slimefun to Break.
this pull fixes this issue.